### PR TITLE
Hero banner netlification

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -169,6 +169,8 @@ const svgSprite = require("eleventy-plugin-svg-sprite");
   }
 
   return {
+    dataTemplateEngine: "liquid",
+
     // Control which files Eleventy will process
     // e.g.: *.md, *.njk, *.html, *.liquid
     templateFormats: ['md', 'njk', 'html', 'liquid'],

--- a/_data/heroAlert.json
+++ b/_data/heroAlert.json
@@ -1,0 +1,3 @@
+{
+  "message": "TTS is hiring, <a href=\"{{ '/join' | url }}\" class=\"usa-link\">Join us!</a>"
+}

--- a/_includes/hero-alert.html
+++ b/_includes/hero-alert.html
@@ -2,8 +2,7 @@
   <div class="usa-alert">
     <div class="usa-alert__body">
       <p class="usa-alert__text">
-        TTS is hiring, 
-        <a class="usa-link" href="{{ '/join' | url }}">Join us!</a>.
+      {{ alert }}
       </p>
     </div>
   </div>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -3,7 +3,7 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
 {% endcomment %}
 
 {% if site.show_site_alert %}
-  {% render "hero-alert.html" %}
+  {% render "hero-alert.html", alert: heroAlert['message'] %}
 {% endif %}
 <section class="usa-hero bg-indigo opacity-90">
   <div class="display-flex grid-container" id="hero-wrapper">

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -42,6 +42,16 @@ collections:
 
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Body", name: "body", widget: "markdown"}
+  - label: Site Alert
+    name: hero-alert
+    create: false
+    format: "json"
+    files:
+      - label: "Hero Alert"
+        name: "hero-alert"
+        file: "_data/heroAlert.json"
+        fields:
+          - {label: 'Message', name: 'message', widget: 'string'}
   - label: Join TTS Info Pages
     name: jointtspages
     folder: pages/jointts/


### PR DESCRIPTION
## Changes proposed in this pull request:
- Rework (and overcomplicate imo) the hero banner so that it pulls its alert from a data file which is hooked up to NetlifyCMS, allowing content editors to have an easier way to change the site alert.
- A config change to Eleventy to having any global data files ran through Liquid first so that we can use filters and other things in them. This PR makes use of this change.

## security considerations
No considerations at this time.
