### PR TITLE
Show search bar in navigation

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -76,17 +76,17 @@ primary_navigation:
   - name: Our Services
     url: /services/
 
-secondary_navigation:
-  - name: Secondary link
-    url: "#main-content"
-  - name: Another secondary link
-    url: "#main-content"
+# secondary_navigation:
+#   - name: Secondary link
+#     url: "#main-content"
+#   - name: Another secondary link
+#     url: "#main-content"
 # Search.gov configuration
 #
 # 1. Create an account with Search.gov https://search.usa.gov/signup
 # 2. Add a new site.
 # 3. Add your site/affiliate name here.
-# searchgov:
+searchgov: "foobar"
 # Only change this if you're using a CNAME. Learn more here: https://search.gov/manual/cname.html
 # endpoint: https://search.usa.gov
 

--- a/_includes/searchgov/form.html
+++ b/_includes/searchgov/form.html
@@ -16,7 +16,7 @@
       <label class="usa-sr-only" for="extended-search-field-small">Search small</label>
       <input class="usa-input usagov-search-autocomplete" id="extended-search-field-small" type="search" name="query" autocomplete="off">
       <button class="usa-button" type="submit">
-        {% image_with_class "./node_modules/@uswds/uswds/src/img/usa-icons-bg/search--white.svg" "usa-search__submit-icon" "Search" %}
+        {% image_with_class "./node_modules/@uswds/uswds/dist/img/usa-icons-bg/search--white.svg" "usa-search__submit-icon" "Search" %}
       </button>
     </div>
   </form>


### PR DESCRIPTION
## Changes proposed in this pull request:
1. fix link to search svg
2. hide secondary links by removing their data
3. add placeholder link to show seach bar

Note: 
The search bar shows when there's a value for the `searchgov` key in `_data/site.yaml` and hides when this value is empty.
When final search.gov url is available, replace `searchgov` placeholder value with this url. 

## security considerations
None (these are frontend changes that don't make any external requests)

Screenshot of top nav with search bar shown:

<img width="1042" alt="Screen Shot 2022-09-20 at 12 42 01 PM" src="https://user-images.githubusercontent.com/4267629/191327481-c4b9b916-9f24-4e36-9007-e37b388afad7.png">


