### PR TITLE
unset background-color on service logos

### DIFF
--- a/styles/tts-custom-styles.scss
+++ b/styles/tts-custom-styles.scss
@@ -40,6 +40,10 @@ $tts-tagline-bg: #1F303E;
   border-radius: 0;
 }
 
+.service .usa-card__img {
+  background-color: unset;
+}
+
 .usa-prose .usa-card {
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `background-color: unset;` to the image/logos on the Service pages so that a gray background no longer shows

## security considerations
None at this time.
