### PR TITLE
Update NetlifyCMS configuration to point to cloud.gov pages

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,9 +2,9 @@
 backend:
   name: github
   repo: GSA-TTS/tts.gsa.gov
-  base_url: https://federalistapp.18f.gov
+  base_url: https://pages.cloud.gov
   auth_endpoint: external/auth/github
-  preview_context: federalist/build
+  preview_context: pages/build
   branch: main
   use_graphql: true
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update NetlifyCMS configuration to point to cloud.gov pages

## security considerations
Pointing to a new authentication API