### PR TITLE
Add build test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+---
+name: Build and Test
+
+# yamllint disable-line rule:truthy
+on: 
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Use Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '17.x'
+
+      - name: Install NPM dependencies
+        run: npm install
+
+      - name: Build site
+        run: npm run build
+
+          #      - name: Run tests
+          #        run: npm run test


### PR DESCRIPTION
## Changes proposed in this pull request:

Per #100, this will add a basic build test.  That is, it will attempt to build the site.  If the site won't build, the test will fail.

Note: there is a commented-out `npm run tests` as the [package.json](https://github.com/GSA-TTS/tts.gsa.gov/blob/main/package.json#L25) shows that the test is designed to fail immediately as there are no tests defined.

## security considerations

This does not have an impact on the security of the site or the repo.
