### PR TITLE
Change Get to Access and fix link

### DIFF
--- a/_includes/highlights.html
+++ b/_includes/highlights.html
@@ -29,8 +29,8 @@ sites will only have two while others may have six to eight.
         {% uswds_icon_with_size "trending_up", "9" %}
         </span>
         <div class="usa-media-block__body">
-          <h3 class="usa-graphic-list__heading">Get the largest federal technology contracts</h3>
-          <p><a href="https://www.gsa.gov/technology/information-technology-category">GSA’s Information Technology Category</a> offers a full suite of IT and telecommunications products, services, and solutions from highly qualified industry partners.</p>
+          <h3 class="usa-graphic-list__heading">Access the largest federal technology contracts</h3>
+          <p><a href="https://www.gsa.gov/technology/it-contract-vehicles-and-purchasing-programs/information-technology-category">GSA’s Information Technology Category</a> offers a full suite of IT and telecommunications products, services, and solutions from highly qualified industry partners.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Changes proposed in this pull request:

This changes "Get the largest federal contracts" (header) and subsequently link to "Access the largest federal contracts" with a fixed link.

## security considerations

n/a
