### PR TITLE
Update LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,9 +2,9 @@
 
 As a work of the [United States government](https://www.usa.gov/), this project is in the public domain within the United States of America.
 
-Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
+Additionally, we waive copyright and related rights in the work worldwide through the CC0-1.0 Universal public domain dedication.
 
-## CC0 1.0 Universal Summary
+## CC0-1.0 Universal Summary
 
 This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
 
@@ -16,6 +16,6 @@ You can copy, modify, distribute, and perform the work, even for commercial purp
 
 ### Other Information
 
-In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+In no way are the patent or trademark rights of any person affected by CC0-1.0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
 
 Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.


### PR DESCRIPTION
[GitHub's documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) uses the keyword `CC0-1.0` (not `CC0 1.0`) so GitHub (hence, Allstar) wasn't picking up the license.

## Changes proposed in this pull request:

This changes `CC0 1.0` to `CC0-1.0` to meet the SPDX license identifier requirements.

This should address [Code Scanning Alert #2](https://github.com/GSA-TTS/tts.gsa.gov/security/code-scanning/2)

## security considerations

n/a
