### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,3 +25,11 @@ Please note that only certain branches are supported with security updates.
 
 When using this code or reporting vulnerabilities please only use supported
 versions.
+
+## Security Researchers
+
+Security researchers shall:
+
+* Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction or manipulation of data.
+* Only use exploits to the extent necessary to confirm a vulnerability. Do not use an exploit to compromise or exfiltrate data, establish command line access and/or persistence, or use the exploit to "pivot" to other systems. Once you've established that a vulnerability exists, or encountered any of the sensitive data outlined above, you must stop your test and notify us immediately.
+* Keep confidential any information about discovered vulnerabilities for up to 90 calendar days after you have notified GSA. For details, please review Coordinated Disclosure. 


### PR DESCRIPTION
This adds a `Security Researchers` section from the [GSA Vulnerability Disclosure Policy](https://www.gsa.gov/vulnerability-disclosure-policy) which includes a request to keep vulnerabilities confidential for 90 days after notifying GSA.  This should satisfy Scorecard.

## Changes proposed in this pull request:

This should address [Security Finding #13](https://github.com/GSA-TTS/tts.gsa.gov/security/code-scanning/13)

## security considerations

n/a
