### PR TITLE
Update spellcheck and markdown link checker

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -48,6 +48,7 @@
     "Grype",
     "dependencies",
     "hotfixes",
-    "Nygard"
+    "Nygard",
+    "HSPD"
   ]
 }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -8,7 +8,7 @@
       "pattern": "^https?://github.com/",
     },
     {
-      pattern: "^http://localhost/"
+      pattern: "^httpsgi?://localhost/"
     },
     {
       pattern: "\{\{[^]*\|[[:space:]]*url[["space:]]* \}]}"]

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,7 +5,13 @@
   "projectBaseUrl": "https://github.com/GSA-TTS/tts-website/",
   "ignorePatterns": [
     {
-      "pattern": "^https?://github.com/"
+      "pattern": "^https?://github.com/",
+    },
+    {
+      pattern: "^http://localhost/"
+    },
+    {
+      pattern: "\{\{[^]*\|[[:space:]]*url[["space:]]* \}]}"]
     }
   ]
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

This ignores the `{{ ... | url }}` patterns and references to `localhost` for the markdown link checker.  It also adds `HSPD` to the spellechecker.

## security considerations

None
