### PR TITLE
Update markdown link check again

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,13 +5,13 @@
   "projectBaseUrl": "https://github.com/GSA-TTS/tts-website/",
   "ignorePatterns": [
     {
-      "pattern": "^https?://github.com/",
+      "pattern": "^https?://github.com/"
     },
     {
-      pattern: "^httpsgi?://localhost/"
+      "pattern": "^https?://localhost/"
     },
     {
-      pattern: "\{\{[^]*\|[[:space:]]*url[["space:]]* \}\}"]
+      "pattern": "\\{"
     }
   ]
 }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -11,7 +11,7 @@
       pattern: "^httpsgi?://localhost/"
     },
     {
-      pattern: "\{\{[^]*\|[[:space:]]*url[["space:]]* \}]}"]
+      pattern: "\{\{[^]*\|[[:space:]]*url[["space:]]* \}\}"]
     }
   ]
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

This fixes a JSON error (:facepalm:) and makes the pattern the `{{ ... | url }}` more inclusive.

## security considerations

none
