### PR TITLE
Update site.yaml

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -106,9 +106,9 @@ primary_navigation:
 # endpoint: https://search.usa.gov
 
 # Replace this with your search.gov account.
-# affiliate: federalist-uswds-example
+affiliate: tts-gsa-gov
 
-# access_key: replace_this_with_your_access_key
+access_key: M2SsxpWBgRu9LVxp0oD1UwKvqfZ2QeBMDpf68b6jhno=
 
 # This renders the results within the page instead of sending to user to search.gov.
 # inline: true


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

Adds Search.gov configuration

## security considerations

I'm not a fan of the API key being stored in the source code in the repo.  That said, I'm told that the key is public and that the accepted practice is to include the key there.  Eleventy documentation asserts that:

>  Environment variables are not available in the templates. 

([source](https://www.11ty.dev/docs/environment-vars/))

So, we would need to find a way to make that happen via JavaScript code.