### PR TITLE
Hardcode closing time

### DIFF
--- a/_includes/layouts/jointts/home.html
+++ b/_includes/layouts/jointts/home.html
@@ -42,7 +42,7 @@ layout: layouts/default
                       {% else %}
                       <a href="{{ pg.url | url }}">{{ pg.data.title }}</a>
                     {% endif %}
-                   (Open now {% if pg.data.weeks_open %}for {% if pg.data.weeks < 52 %}{{ pg.data.weeks }}{% else %} one year or until all selections have been made{% endif %},{% endif %} through {{ pg.data.closes | date: '%A, %B %e, %Y at %l:%M%P' }} EST)
+                   (Open now {% if pg.data.weeks_open %}for {% if pg.data.weeks < 52 %}{{ pg.data.weeks }}{% else %} one year or until all selections have been made{% endif %},{% endif %} through {{ pg.data.closes | date: '%A, %B %e, %Y at 11:59pm' }} ET)
                    {% if pg.data.info_sessions and pg.data.info_sessions.size > 0 %}
                         <aside class="usa-alert usa-alert-info">
                           <div class="usa-alert-body">


### PR DESCRIPTION
hardcode closing time

<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

Per [Slack](https://gsa-tts.slack.com/archives/C07G57Q62E6/p1726518599114499), the posting closing times were showing up as 12:00am instead of 11:59pm.  This hard-codes the time to 11:59pm.

## security considerations

None