### PR TITLE
Update Search box with correct affiliate id

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -64,7 +64,7 @@ manage your navigation system {% endcomment %}
 
       <section aria-label="Small search component">
         <form class="usa-search usa-search--small" role="search" action="https://search.usa.gov/search" accept-charset="UTF-8" method="get">
-          <input name="affiliate" type="hidden" value="tts">
+          <input name="affiliate" type="hidden" value="tts-gsa-gov">
           <label class="usa-sr-only" for="search-field-en-small">Search</label>
           <input
             class="usa-input"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

This corrects the affiliate-id for the Search box

## security considerations

None.