### PR TITLE
Update the text of the "Built with" line on the site footer.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,7 @@
           </div>
           <div class="mobile-lg:grid-col-auto">
             <p class="usa-footer__logo-heading">Technology Transformation Services</p>
-            <p style="font-size: .875rem;"><strong>Built with:</strong> <a href="https://designsystem.digital.gov/whats-new/updates/2022/04/28/introducing-uswds-3-0/">USWDS 3</a> | <a href="https://cloud.gov/pages/">Cloud.gov Pages</a> | <a href="https://digital.gov/guides/dap/">Digital Analytics Platform</a></p>
+            <p style="font-size: .875rem;"><strong>Built with:</strong> <a href="https://designsystem.digital.gov/whats-new/updates/2022/04/28/introducing-uswds-3-0/">USWDS 3</a> | <a href="https://cloud.gov/pages/">Cloud.gov Pages</a> | <a href="https://digital.gov/guides/dap/">Digital Analytics Program</a></p>
             <p style="font-size: .875rem;">Tell us about your experience using this website by completing the <a href="https://touchpoints.app.cloud.gov/touchpoints/39b4b09d/submit" target="_blank" style="text-decoration: underline;">feedback survey</a>. Your feedback is anonymous and will be used to make improvements.</p>
           </div>
         </div>


### PR DESCRIPTION
Looks like the Digital Analytics Program (DAP) is misnamed in the footer.

<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

- Update the text of the "Built with" line on the site footer.

## Security considerations

None, text changes only.
