### PR TITLE
Load several configuration values from the environment

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -63,7 +63,38 @@ module.exports = function (config) {
 
   const { hosts } = yaml.load(fs.readFileSync("./_data/site.yaml", "utf8"));
 
-  if (process.env.BRANCH) {
+  function isValidGitBranch(branch) {
+    const validGitBranch = /^[a-zA-Z0-9_\-\.\/]+$/;
+    return validGitBranch.test(branch);
+  }
+
+  function isValidTwitterHandle(handle) {
+    const validTwitterHandle = /^\w{1,15}$/;
+    return validTwitterHandle.test(handle);
+}
+
+  function isValidDapAgency(agency) {
+    const validDapAgency = /^\w{1,15}$/;
+    return validDapAgency.test(agency);
+  }
+
+  function isValidAnalyticsId(ga) {
+    const validAnalyticsId = /^(G|UA|YT|MO)-[a-zA-Z0-9-]+$/;
+    return validAnalyticsId.test(ga);
+  }
+
+  function isValidSearchKey(accessKey) {
+    const validSearchKey = /^[0-9a-zA-Z]{1,}=*$/;
+    return validSearchKey.test(accessKey);
+  }
+
+  function isValidSearchAffiliate(affiliate) {
+    const validSearchAffiliate = /^[0-9a-z]{1,}$/;
+    return validSearchAffiliate.test(affiliate);
+  }
+
+
+  if (process.env.BRANCH && isValidGitBranch(process.env.BRANCH)) {
     switch (process.env.BRANCH) {
       case "main":
         baseUrl = new URL(hosts.live).href.replace(/\/$/, "");
@@ -79,27 +110,27 @@ module.exports = function (config) {
   config.addGlobalData("baseUrl", baseUrl);
   config.addGlobalData("site.baseUrl", baseUrl);
 
-  if (process.env.TWITTER) {
+  if (process.env.TWITTER && isValidTwitterHandle(process.env.TWITTER)) {
     config.addGlobalData("site.twitter", process.env.TWITTER);
   }
 
-  if (process.env.DAP_AGENCY) {
+  if (process.env.DAP_AGENCY && isValidDapAgency(process.env.DAP_AGENCY)) {
     config.addGlobalData("site.dap.agency", process.env.DAP_AGENCY);
   }
 
-  if (process.env.DAP_SUBAGENCY) {
+  if (process.env.DAP_SUBAGENCY && isValidDapAgency(process.env.DAP_SUBAGENCY)) {
     config.addGlobalData("site.dap.subagency", process.env.DAP_SUBAGENCY);
   }
 
-  if (process.env.GA) {
+  if (process.env.GA && isValidAnalyticsId(process.env.GA)) {
     config.addGlobalData("site.ga", process.env.GA);
   }
 
-  if (process.env.SEARCH_ACCESS_KEY) {
+  if (process.env.SEARCH_ACCESS_KEY && isValidSearchKey(process.env.SEARCH_ACCESS_KEY)) {
     config.addGlobalData("site.access_key", process.env.SEARCH_ACCESS_KEY);
   }
 
-  if (process.env.SEARCH_AFFILIATE) {
+  if (process.env.SEARCH_AFFILIATE && isValidSearchAffiliate(process.env.SEARCH_AFFILIATE)) {
     config.addGlobalData("site.affiliate", process.env.SEARCH_AFFILIATE);
   }
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -71,7 +71,7 @@ module.exports = function (config) {
   function isValidTwitterHandle(handle) {
     const validTwitterHandle = /^\w{1,15}$/;
     return validTwitterHandle.test(handle);
-}
+  }
 
   function isValidDapAgency(agency) {
     const validDapAgency = /^\w{1,15}$/;
@@ -92,7 +92,6 @@ module.exports = function (config) {
     const validSearchAffiliate = /^[0-9a-z-]{1,}$/;
     return validSearchAffiliate.test(affiliate);
   }
-
 
   if (process.env.BRANCH && isValidGitBranch(process.env.BRANCH)) {
     switch (process.env.BRANCH) {
@@ -118,7 +117,10 @@ module.exports = function (config) {
     config.addGlobalData("site.dap.agency", process.env.DAP_AGENCY);
   }
 
-  if (process.env.DAP_SUBAGENCY && isValidDapAgency(process.env.DAP_SUBAGENCY)) {
+  if (
+    process.env.DAP_SUBAGENCY &&
+    isValidDapAgency(process.env.DAP_SUBAGENCY)
+  ) {
     config.addGlobalData("site.dap.subagency", process.env.DAP_SUBAGENCY);
   }
 
@@ -126,11 +128,17 @@ module.exports = function (config) {
     config.addGlobalData("site.ga", process.env.GA);
   }
 
-  if (process.env.SEARCH_ACCESS_KEY && isValidSearchKey(process.env.SEARCH_ACCESS_KEY)) {
+  if (
+    process.env.SEARCH_ACCESS_KEY &&
+    isValidSearchKey(process.env.SEARCH_ACCESS_KEY)
+  ) {
     config.addGlobalData("site.access_key", process.env.SEARCH_ACCESS_KEY);
   }
 
-  if (process.env.SEARCH_AFFILIATE && isValidSearchAffiliate(process.env.SEARCH_AFFILIATE)) {
+  if (
+    process.env.SEARCH_AFFILIATE &&
+    isValidSearchAffiliate(process.env.SEARCH_AFFILIATE)
+  ) {
     config.addGlobalData("site.affiliate", process.env.SEARCH_AFFILIATE);
   }
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -77,6 +77,31 @@ module.exports = function (config) {
   }
 
   config.addGlobalData("baseUrl", baseUrl);
+  config.addGlobalData("site.baseUrl", baseUrl);
+
+  if (process.env.TWITTER) {
+    config.addGlobalData("site.twitter", process.env.TWITTER);
+  }
+
+  if (process.env.DAP_AGENCY) {
+    config.addGlobalData("site.dap.agency", process.env.DAP_AGENCY);
+  }
+
+  if (process.env.DAP_SUBAGENCY) {
+    config.addGlobalData("site.dap.subagency", process.env.DAP_SUBAGENCY);
+  }
+
+  if (process.env.GA) {
+    config.addGlobalData("site.ga", process.env.GA);
+  }
+
+  if (process.env.SEARCH_ACCESS_KEY) {
+    config.addGlobalData("site.access_key", process.env.SEARCH_ACCESS_KEY);
+  }
+
+  if (process.env.SEARCH_AFFILIATE) {
+    config.addGlobalData("site.affiliate", process.env.SEARCH_AFFILIATE);
+  }
 
   // Template function used to sort a collection by a certain property
   // Ex: {% assign sortedJobs = collection.jobs | sortByProp: "title" %}

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -89,7 +89,7 @@ module.exports = function (config) {
   }
 
   function isValidSearchAffiliate(affiliate) {
-    const validSearchAffiliate = /^[0-9a-z]{1,}$/;
+    const validSearchAffiliate = /^[0-9a-z-]{1,}$/;
     return validSearchAffiliate.test(affiliate);
   }
 

--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -12,56 +12,12 @@ description: >- # this means to ignore newlines
   modern applications, platforms, processes, personnel, and software
   solutions.
 
-# Twitter handle. Only the handle, not the URL.
-twitter: GSA_TTS
-
 # Whether or not to render the "Suggest edits to this page on GitHub" link on pages
 allow_page_edits: true
 
 # Whether or not to render the alert in the hero
 show_site_alert: true
 
-#################################################################
-#
-# Digital Analytics Program (DAP) configuration
-#
-# USAID   - Agency for International Development
-# USDA    - Department of Agriculture
-# DOC     - Department of Commerce
-# DOD     - Department of Defense
-# ED      - Department of Education
-# DOE     - Department of Energy
-# HHS     - Department of Health and Human Services
-# DHS     - Department of Homeland Security
-# HUD     - Department of Housing and Urban Development
-# DOJ     - Department of Justice
-# DOL     - Department of Labor
-# DOS     - Department of State
-# DOI     - Department of the Interior
-# TREAS   - Department of the Treasury
-# DOT     - Department of Transportation
-# VA      - Department of Veterans Affairs
-# EPA     - Environmental Protection Agency
-# EOP     - Executive Office of the President
-# GSA     - General Services Administration
-# NASA    - National Aeronautics and Space Administration
-# NARA    - National Archives and Records Administration
-# NSF     - National Science Foundation
-# NRC     - Nuclear Regulatory Commission
-# OPM     - Office of Personnel Management
-# USPS    - Postal Service
-# SBA     - Small Business Administration
-# SSA     - Social Security Administration
-#
-#################################################################
-dap:
-  agency: GSA
-
-  # Optional
-  # subagency: your-subagency
-
-# Configuration for Google Analytics
-ga: G-4K89W87795
 
 # Site Navigation
 primary_navigation:
@@ -96,29 +52,12 @@ primary_navigation:
 #     url: "#main-content"
 #   - name: Another secondary link
 #     url: "#main-content"
-# Search.gov configuration
-#
-# 1. Create an account with Search.gov https://search.usa.gov/signup
-# 2. Add a new site.
-# 3. Add your site/affiliate name here.
-# searchgov: "foobar"
-# Only change this if you're using a CNAME. Learn more here: https://search.gov/manual/cname.html
-# endpoint: https://search.usa.gov
 
-# Replace this with your search.gov account.
-affiliate: tts-gsa-gov
-
-access_key: M2SsxpWBgRu9LVxp0oD1UwKvqfZ2QeBMDpf68b6jhno=
-# This renders the results within the page instead of sending to user to search.gov.
-# inline: true
-
+suggestions: true
 hosts:
   live: https://tts.gsa.gov/
   preview: https://federalist-a2423046-fe43-4e75-a2ef-2651e5e123ca.sites.pages.cloud.gov/
   undefined: http://localhost:8080/
-# This allows Search.gov to present relevant type-ahead search suggestions in your website's search box.
-# If you do not want to present search suggestions, set this value to false.
-# suggestions: true
 ##########################################################################################
 # The values below here are more advanced and should only be
 # changed if you know what they do

--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -53,6 +53,10 @@ primary_navigation:
 #   - name: Another secondary link
 #     url: "#main-content"
 
+dap:
+  agency: GSA
+
+
 suggestions: true
 hosts:
   live: https://tts.gsa.gov/

--- a/env.sample
+++ b/env.sample
@@ -1,0 +1,52 @@
+## This is a sample '.env' file.  It contains environment variables
+## that the project can use when building the site.  By default,
+## Eleventy won't expose environment variables to templates -- they
+## need to be manually extracted from the environment and added
+## as global data (e.g., `via addGlobalData()` in a JavaScript file).
+##
+## Variables set here take precedence over values specified in
+## configuration files (e.g., '_data/site.yaml`).  Variables
+## that are set in the actual environment (not just this file)
+## take precedence over variables set here.
+##
+## Because '.env' files often contain values that are best left
+## not exposed to the world, it's common to exclude '.env' files
+## from Git repositories.  Moreover, it's generally not helpful
+## to have one's local configuration wiped out when they fetch
+## updates from an upstream repository.  Therefore, this sample
+## file is named 'env.sample' instead of '.env'.
+##
+## This values specified here aren't considered a security
+## concern if they were publicly available (e.g., in a public
+## Git repository).  That said, it's considered preferable by
+## some to extract values like credentials, tokens, API keys,
+## etc. out of source code and, instead, provide them at runtime.
+## In addition to enhanced security stance, this also helps
+## developers test their changes without fear of pushing test
+## data into analytics, for example.
+
+# GA is the Google Analytics ID used in conjunction with DAP; it
+# is accessed via global 'site.ga' variable.
+GA=G-xxxxxxxx
+
+# DAP_AGENCY is the 'agency' provided to DAP; it is accessed via
+# the global 'site.dap.agency' variable.
+DAP_AGENCY=XXXX
+
+# DAP_SUBAGENCY is the 'subagency' provided to DAP; it is accessed
+# via the global 'site.dap.subagency' variable.
+DAP_SUBAGENCY=XXXX
+
+# TWITTER is the X (formerly Twitter) handle associated with the
+# site; it's accessed via the global 'site.twitter' variable.
+TWITTER=XXXXXX
+
+# SEARCH_ACCESS_KEY is the access key used to interact with the
+# Search.gov service; it is accessed via the global variable
+# 'site.access_key'.
+SEARCH_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=
+
+# SEARCH_AFFILIATE is the affiliate id used to tag pages so
+# that Search.gov can collate groups of related pages; it's
+# accessed via the global 'site.affiliate' variable.
+SEARCH_AFFILIATE=xxxx-xxxx-xxxx


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

- for several configuration values, if they're passed as environment variables (e.g., during a build), they'll be included from the environment
- these changes only apply to when someone passed values as environment values; passing via _data/site.yml (or wherever) is still supported; nothing here breaks existing implementations
- `.env` files are supported (from an earlier update)
- `dap.agency` isn't supported here because Pages requires values to be >= 4 characters long and our value is only 3 characters long

## security considerations

- the values being read from the environment are not sanitized or validated; given that they'll only be accessed at build time and in an ephemeral environment, this is less of a concern, but it should still be addressed.
