### PR TITLE
Fix assignees from content update form

### DIFF
--- a/.github/ISSUE_TEMPLATE/content_update_form.yml
+++ b/.github/ISSUE_TEMPLATE/content_update_form.yml
@@ -5,8 +5,6 @@ projects:
   - GSA-TTS/54
 labels:
   - "Content Update"
-assignees:
-  - "GSA-TTS/tts-website-content"
 
 body:
   - type: "markdown"


### PR DESCRIPTION
Merge pull request #334 from GSA-TTS/321-update-global-sessions<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

Just remove it completely.

## security considerations

None.
