### PR TITLE
Cleanup linter warning

### DIFF
--- a/pages/jointts/faq.md
+++ b/pages/jointts/faq.md
@@ -44,7 +44,9 @@ and new hires.
 - Although we cannot set up 1:1 calls with prospective candidates, we do host
 monthly information sessions that include plenty of time to answer questions.
 You can find a list of our upcoming sessions on the
+<!-- markdownlint-disable MD033 -->
 <a href="{{ '/join' | url }}" class="usa-link">Join TTS</a>.
+<!-- markdownlint-enable MD033 -->
 
 - You can also find info on
   [Working at TTS](https://handbook.tts.gsa.gov/about-us/tts-history/)
@@ -86,7 +88,9 @@ You can find a list of our upcoming sessions on the
 ### Do you have any tips on preparing a federal style resume?
 
 - Yes! We recommend checking out the
+- <!-- markdownlint-disable MD033 -->
   <a href="{{ '/join/resume' | url }}" class="usa-link">preparing your resume section</a>
+  <!-- markdownlint-enable MD033 -->
   , as well as a
   [sample resume](https://handbook.tts.gsa.gov/hiring-staying-or-changing-jobs/resume/)
   in our Handbook that was created by a TTS employee.


### PR DESCRIPTION
Disables inline HTML lint check around our manually-incorporated links.

I'm wondering if it's possible to replace this:

```HTML
<a href="{{ foo | url }}">bar</a>
```

with this:

```markdown
[bar]({{ foo | url }})
```

:thinking:

<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

-
-
-

## security considerations

None.
