### PR TITLE
349 minify resources

### DIFF
--- a/bin/conditional_minify.bash
+++ b/bin/conditional_minify.bash
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-#if [[ "$BRANCH" =~ (main|staging) ]] ; then
+if [[ "$BRANCH" =~ (main|staging) ]] ; then
   bin/minify.bash
-#fi
+fi

--- a/bin/conditional_minify.bash
+++ b/bin/conditional_minify.bash
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-if [[ "$BRANCH" =~ (main|staging) ]] ; then
+if [[ "$BRANCH" =~ (main|staging) ]]; then
   bin/minify.bash
 fi

--- a/bin/conditional_minify.bash
+++ b/bin/conditional_minify.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#if [[ "$BRANCH" =~ (main|staging) ]] ; then
+  bin/minify.bash
+#fi

--- a/bin/minify.bash
+++ b/bin/minify.bash
@@ -30,7 +30,6 @@ set -euo pipefail
 ## location="_site/assets" bin/minimize.bash
 ## @endcode
 
-
 ## @var location
 ## @brief where to look for files to minimize (default: _site)
 location="${location:-_site}"
@@ -75,7 +74,6 @@ modified_filename() {
   echo "$new_filename"
 }
 
-
 ## @fn minimize()
 ## @brief given 0 or more filenames, attempt to minimize them
 ## @details
@@ -101,7 +99,7 @@ modified_filename() {
 ## minimize "_site/assets/style/stylesheet.css"
 ## @endcode
 minimize() {
-  for old_filename in "$@" ; do
+  for old_filename in "$@"; do
 
     echo "Processing '$old_filename'"
     new_filename="$(modified_filename "$old_filename" "$filename_modifier")"
@@ -117,7 +115,7 @@ minimize() {
         mv -f "$old_filename" "$new_filename" || return 2
         terser --compress -o "$old_filename" "$new_filename" || return 1
         ;;
-      htm|html)
+      htm | html)
         echo "  HTML"
         mv -f "$old_filename" "$new_filename" || return 2
         html-minifier-terser -o "$old_filename" --collapse-whitespace --remove-comments --minify-css true --minify-js true "$new_filename" || return 1
@@ -137,7 +135,7 @@ export location filename_modifier
 ## @brief the main function
 main() {
 
-  for filetype in css js htm html ; do
+  for filetype in css js htm html; do
     find "$location" \
       -type f \
       -name "*.$filetype" \

--- a/bin/minify.bash
+++ b/bin/minify.bash
@@ -120,7 +120,7 @@ minimize() {
       htm|html)
         echo "  HTML"
         mv -f "$old_filename" "$new_filename" || return 2
-        html-minifier-terser  --collapse-whitespace --remove-comments "$new_filename" > "$old_filename" || return 1
+        html-minifier-terser -o "$old_filename" --collapse-whitespace --remove-comments --minify-css true --minify-js true "$new_filename" || return 1
         ;;
       *)
         echo "Don't know how to handle '$file_type' files"

--- a/bin/minify.bash
+++ b/bin/minify.bash
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+## @file minimize.bash
+## @author TTS Website Team
+## @brief uglify (minimize) our CSS and JavaScript
+## @details
+## There are two npm modules, uglifycss and uglifyjs that will
+## remove whitespace, comments, etc. from CSS and JavaScript,
+## respectively.  This will iterate across all of the CSS and
+## JavaScript files in the site's built files.  The original
+## files will be renamed with a .orig. before the extension
+## (e.g., style.css => style.orig.css) and the minimized
+## version will replace the original.  (e.g., style.css
+## will be minimized while style.orig.css will remain
+## unmodfied).
+##
+## This process could be reversed (e.g., style.css would
+## remain unmodified by style.min.css would be minimized);
+## however, this would require the calling HTML and such
+## to use be modified to use the minimized filenames.
+##
+## @par Examples
+## @code
+## # Use the defaults and do the thing
+## bin/minimize.bash
+##
+## # set a custom location
+## location="_site/assets" bin/minimize.bash
+## @endcode
+
+
+## @var location
+## @brief where to look for files to minimize (default: _site)
+location="${location:-_site}"
+
+## @var filename_modifier
+## @brief what to insert into a filename when modifying it (default: .orig.)
+filename_modifier="${filename_modifier:-.orig.}"
+
+## @fn modified_filename()
+## @brief return a modified version of the file
+## @details
+## This accepts a filename as an argument and returns a modified version
+## of that filename via STDOUT.  The filename is modified by adding
+## a string before the file's extension.  So, if the modifier is
+## '.min.' and the filename is 'style.css', the modified version of the
+## filename is 'style.min.css'.
+##
+## The modified filename is determined by actions on a string; it doesn't
+## actually look at the filesystem, it doesn't matter if the filename
+## actually exists, the filename can be read or not, the resulting
+## modified filename can actually be written, etc..  It's just string
+## manipulation.
+##
+## @param filename the original filename to examine
+## @param modifier the string to insert befor the extension (default: .min.)
+## @returns the modified filename via STDOUT
+## @retval 0 (True) if the filename could be modified
+## @retval 1 (False) otherwise (should never happen)
+## @par Examples
+## @code
+## new_filename="$(modified_filename "$old_filename")"
+## @endcode
+modified_filename() {
+  filename="${1?Error: no filename passed}"
+  modifier="${2:-.min.}"
+
+  extension="${filename##*.}"
+  filebase="${filename%%.*}"
+
+  new_filename="${filebase}${modifier}${extension}"
+
+  echo "$new_filename"
+}
+
+
+## @fn minimize()
+## @brief given 0 or more filenames, attempt to minimize them
+## @details
+## This accepts a list of filenames and iterates across them.
+## For each filename, it will acquire the modified filename,
+## rename the original file to the modified filename, and
+## then minimize the original filename to the original filename.
+##
+## 1. mv old new
+## 2. minimize new > old
+##
+## The file's extension is examined to determine how the
+## file should be minifed.  For example, CSS and JavaScript files
+## are minified with 'uglifycss' and 'uglifyjs', respectively.
+## This allows us to expand the script in the future to accept
+## different file types.
+## @param old_filename[] list of files to modify
+## @retval 0 (True) if the file(s) were minified
+## @retval 1 (False) if the file could not be minified
+## @retval 2 (False) if the file could not be renamed
+## @par Examples
+## @code
+## minimize "_site/assets/style/stylesheet.css"
+## @endcode
+minimize() {
+  for old_filename in "$@" ; do
+
+    echo "Processing '$old_filename'"
+    new_filename="$(modified_filename "$old_filename" "$filename_modifier")"
+
+    file_type="${old_filename##*.}"
+
+    case "$file_type" in
+      css)
+        mv -f "$old_filename" "$new_filename" || return 2
+        cleancss -o "$old_filename" "$new_filename" || return 1
+        ;;
+      js)
+        mv -f "$old_filename" "$new_filename" || return 2
+        terser --compress -o "$old_filename" "$new_filename" || return 1
+        ;;
+      htm|html)
+        echo "  HTML"
+        mv -f "$old_filename" "$new_filename" || return 2
+        html-minifier-terser  --collapse-whitespace --remove-comments "$new_filename" > "$old_filename" || return 1
+        ;;
+      *)
+        echo "Don't know how to handle '$file_type' files"
+        exit 1
+        ;;
+    esac
+  done
+}
+
+export -f minimize modified_filename
+export location filename_modifier
+
+## @fn main()
+## @brief the main function
+main() {
+
+  for filetype in css js htm html ; do
+    find "$location" \
+      -type f \
+      -name "*.$filetype" \
+      \! -name "*.orig.*" \
+      -exec bash -c 'minimize "$0"' {} \;
+  done
+}
+
+# if we're not being sourced and there's a function named `main`, run it
+[[ "$0" == "${BASH_SOURCE[0]}" ]] && [ "$(type -t "main")" == "function" ] && main "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,13 @@
         "@11ty/eleventy-plugin-rss": "^1.1.2",
         "autoprefixer": "^10.4.2",
         "chokidar-cli": "^3.0.0",
+        "clean-css": "^5.3.3",
+        "clean-css-cli": "^5.6.3",
         "dotenv": "^16.4.5",
         "eleventy-plugin-svg-sprite": "^2.4.2",
         "esbuild": "^0.14.25",
         "esbuild-sass-plugin": "^2.2.4",
+        "html-minifier-terser": "^7.2.0",
         "js-yaml": "^4.1.0",
         "luxon": "^2.3.1",
         "markdown-it": "^12.3.2",
@@ -31,7 +34,8 @@
         "postcss": "^8.4.31",
         "postcss-cli": "^9.1.0",
         "rimraf": "^3.0.2",
-        "start-server-and-test": "^2.0.3"
+        "start-server-and-test": "^2.0.3",
+        "terser": "^5.33.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -494,6 +498,64 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1617,6 +1679,12 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -1643,6 +1711,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/camelcase": {
@@ -1784,6 +1862,88 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
       "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ=="
+    },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/clean-css-cli": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/clean-css-cli/-/clean-css-cli-5.6.3.tgz",
+      "integrity": "sha512-MUAta8pEqA/d2DKQwtZU5nm0Og8TCyAglOx3GlWwjhGdKBwY4kVF6E5M6LU/jmmuswv+HbYqG/dKKkq5p1dD0A==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "clean-css": "^5.3.3",
+        "commander": "7.x",
+        "glob": "^7.1.6"
+      },
+      "bin": {
+        "cleancss": "bin/cleancss"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/clean-css-cli/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/cliui": {
       "version": "5.0.0",
@@ -2401,6 +2561,16 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ]
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.4.5",
@@ -3847,6 +4017,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/html-minifier-terser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.15.1"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/http-equiv-refresh": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-2.0.1.tgz",
@@ -4701,6 +4892,15 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -5028,6 +5228,16 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/node-abi": {
       "version": "3.67.0",
@@ -5619,6 +5829,16 @@
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
       "dev": true
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5657,6 +5877,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -6653,6 +6883,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -7261,6 +7500,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/spdx-correct": {
@@ -8022,6 +8271,30 @@
       "dependencies": {
         "streamx": "^2.12.5"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.33.0.tgz",
+      "integrity": "sha512-JuPVaB7s1gdFKPKTelwUyRq5Sid2A3Gko2S0PncwdBq7kN9Ti9HPWDQ06MPsEDGsZeVESjKEnyGy68quBk1w6g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/text-decoder": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:assets": "npm run assets:refresh && npm run assets:watch",
     "dev:debug": "DEBUG=* npx @11ty/eleventy --serve --watch",
     "dev:serve": "npx @11ty/eleventy --serve --watch",
-    "federalist": "npm run build && if [ ! \"$BRANCH\" == \"main\" ] ; then bin/minify.bash ; fi",
+    "federalist": "npm run build && bin/conditional_minify.bash",
     "pa11y-ci": "npx start-server-and-test start 8080 pa11y-ci:local",
     "pa11y-ci:local": "pa11y-ci http://localhost:8080",
     "serve": "npx @11ty/eleventy --serve",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:assets": "npm run assets:refresh && npm run assets:watch",
     "dev:debug": "DEBUG=* npx @11ty/eleventy --serve --watch",
     "dev:serve": "npx @11ty/eleventy --serve --watch",
-    "federalist": "npm run build && bin/minify.bash",
+    "federalist": "npm run build && if [ ! \"$BRANCH\" == \"main\" ] ; then bin/minify.bash ; fi",
     "pa11y-ci": "npx start-server-and-test start 8080 pa11y-ci:local",
     "pa11y-ci:local": "pa11y-ci http://localhost:8080",
     "serve": "npx @11ty/eleventy --serve",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:assets": "npm run assets:refresh && npm run assets:watch",
     "dev:debug": "DEBUG=* npx @11ty/eleventy --serve --watch",
     "dev:serve": "npx @11ty/eleventy --serve --watch",
-    "federalist": "npm run build",
+    "federalist": "npm run build && bin/minify.bash",
     "pa11y-ci": "npx start-server-and-test start 8080 pa11y-ci:local",
     "pa11y-ci:local": "pa11y-ci http://localhost:8080",
     "serve": "npx @11ty/eleventy --serve",
@@ -32,10 +32,13 @@
     "@11ty/eleventy-plugin-rss": "^1.1.2",
     "autoprefixer": "^10.4.2",
     "chokidar-cli": "^3.0.0",
+    "clean-css": "^5.3.3",
+    "clean-css-cli": "^5.6.3",
     "dotenv": "^16.4.5",
     "eleventy-plugin-svg-sprite": "^2.4.2",
     "esbuild": "^0.14.25",
     "esbuild-sass-plugin": "^2.2.4",
+    "html-minifier-terser": "^7.2.0",
     "js-yaml": "^4.1.0",
     "luxon": "^2.3.1",
     "markdown-it": "^12.3.2",
@@ -45,7 +48,8 @@
     "postcss": "^8.4.31",
     "postcss-cli": "^9.1.0",
     "rimraf": "^3.0.2",
-    "start-server-and-test": "^2.0.3"
+    "start-server-and-test": "^2.0.3",
+    "terser": "^5.33.0"
   },
   "dependencies": {
     "@uswds/uswds": "3.8.1"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

This adds a step to the `federalist` script to minify our resources (HTML, CSS, JavaScript) upon page build and replace the original version (which are generated at build time) with their minified versions (which aren't stored in the repo) when builds take place on `main` or `staging` (but not the rest of the preview branches).

#349 

## security considerations

None.
