### PR TITLE
Fix pa11y default branch

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -56,7 +56,7 @@ jobs:
             elif [ -n "${GITHUB_HEAD_REF:-}" ] ; then
               echo "${GITHUB_HEAD_REF}/"
             else
-              echo "echo-summer20203/"
+              echo "staging/"
             fi
 
             echo -n "DELAY_SECONDS="


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

Changes the default path for `pa11y` to scan

## security considerations

none
