### PR TITLE
Update CODEOWNERS to allow developers to approve PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -23,4 +23,4 @@
 *.png @GSA-TTS/tts-website-content
 *.jpg @GSA-TTS/tts-website-content
 
-.github @GSA-TTS/tts-website-admins
+.github @GSA-TTS/tts-website-developers


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->

This updates CODEOWNERS to allow tts-website-developers to approve PRs on files in `.github/`

## security considerations

The list of people who can edit files in `.github/` (e.g., workflows) is now larger.
