### PR TITLE
Add info session syntax to comment block

### DIFF
--- a/pages/jointts/positions/position-template.md
+++ b/pages/jointts/positions/position-template.md
@@ -117,7 +117,8 @@ key_objectives:
 # IMPORTANT: If the position does not have any info sessions, you MUST delete everything
 # except "info_sessions:"
 # 
-# Use the following syntax to add info sessions 
+# If info session details previously removed, use the following syntax to add one.  
+# Duplicate the entire block - link, date, and time - if you need to add more than one session
 # info_sessions:
 # - link: 
 #   date: 

--- a/pages/jointts/positions/position-template.md
+++ b/pages/jointts/positions/position-template.md
@@ -116,6 +116,12 @@ key_objectives:
 #
 # IMPORTANT: If the position does not have any info sessions, you MUST delete everything
 # except "info_sessions:"
+# 
+# Use the following syntax to add info sessions 
+# info_sessions:
+# - link: 
+#   date: 
+#   time: 
 info_sessions:
   - link: 
     date: 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

Since info session syntax is frequently removed when posting is initially added to site, adding info session syntax to comment block to help users when they have info sessions to add

## security considerations
None

[Note the any security considerations here, or make note of why there are none]
