### PR TITLE
Add noopener annotations to links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -67,7 +67,7 @@ official government website
   </div>
 </div>
 <div class="usa-overlay"></div>
-<a class="tts-survey" href="https://touchpoints.app.cloud.gov/touchpoints/fc513d86/submit" target="_blank">
+<a class="tts-survey" href="https://touchpoints.app.cloud.gov/touchpoints/fc513d86/submit" target="_blank" rel="noopener">
   Help us improve our site
 </a>
 </div>

--- a/_includes/layouts/jointts/job/how_to_apply.html
+++ b/_includes/layouts/jointts/job/how_to_apply.html
@@ -21,11 +21,11 @@
 {% elsif state == 'open' %}
   {% if max_applications != 0 %}
     <p class="usa-alert-text">This role is open for applications until {{ closes | date: "%A, %B %d, %Y" }} at 11:59PM ET or until {{max_applications}} applications have been received. 
-      Please fill out all applicable fields. <a href="{{ application_link }}" target="_blank">Click here to apply</a>.
+      Please fill out all applicable fields. <a href="{{ application_link }}" target="_blank" rel="noopener">Click here to apply</a>.
     </p>
   {% else %}
     <p class="usa-alert-text">This role is open for applications until {{ closes | date: "%A, %B %d, %Y" }} at 11:59PM ET. 
-      Please fill out all applicable fields. <a href="{{ application_link }}" target="_blank">Click here to apply</a>.
+      Please fill out all applicable fields. <a href="{{ application_link }}" target="_blank" rel="noopener">Click here to apply</a>.
     </p>
   {% endif %}
   <p><strong>Need Assistance in applying or have questions regarding this job opportunity, please email the 

--- a/_includes/layouts/jointts/job/salary.html
+++ b/_includes/layouts/jointts/job/salary.html
@@ -10,7 +10,7 @@
 </p>
 <p>Your salary, including base and locality, will be determined upon selection, dependent on your actual duty location. 
   Please note the maximum salary available for the GS pay system is $191,900. For specific details on locality pay, please 
-  visit <a href="https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/" target="_blank">OPM's Salaries & Wages page</a> or for a salary calculator 
-  <a href="https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule-gs-salary-calculator/" target="_blank">OPM's 2024 General Schedule (GS) Salary Calculator</a>. 
+  visit <a href="https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/" target="_blank" rel="noopener">OPM's Salaries & Wages page</a> or for a salary calculator 
+  <a href="https://www.opm.gov/policy-data-oversight/pay-leave/salaries-wages/2024/general-schedule-gs-salary-calculator/" target="_blank" rel="noopener">OPM's 2024 General Schedule (GS) Salary Calculator</a>. 
   You can find more information in our <a href="/join/compensation-and-benefits/" target="_blank">compensation and benefits section</a>.
 </p>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

This adds `rel="noopener"` to several links to satisfy SonarQube's low findings.

## security considerations

This ought to address [Web:S5148](https://sonarqube.syr.blueandpurple.com/coding_rules?open=Web%3AS5148&rule_key=Web%3AS5148)

#closes 565
