### PR TITLE
Update scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,7 +16,7 @@ on:
     - cron: "43 7 * * 3"
   push:
     branches:
-      - "main"
+      - "staging"
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

Scorecard was failing because it was being called on `main` which is no longer the default branch (`staging` is).

## security considerations

None
