### PR TITLE
Add main branch protection

### DIFF
--- a/.github/workflows/protect_main_branch.yml
+++ b/.github/workflows/protect_main_branch.yml
@@ -1,0 +1,26 @@
+---
+name: Main Branch Protection
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  protect-main-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        run: |
+          if [[ ${GITHUB_HEAD_REF} != staging ]] \
+          && ! [[ ${GITHUB_HEAD_REF} =~ ^hotfix/ ]] ; then
+            echo "Error: Pull requests to 'main' must come from 'staging' or a 'hotfix/' branch"
+            exit 1
+          fi


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

This check fails when an attempt to merge a branch into `main` that isn't named `staging` or `hotfix/` 

## security considerations

This ought to enforce a second review before commits are merged into `main`.
