### PR TITLE
Require package hashes for pip and npm

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: "18"
 
       - name: Install dependencies
-        run: npm install --require-hashes --production=false && pip install -r requirements.txt
+        run: npm install --production=false && pip install --require-hashes -r requirements.txt
 
       - name: Setup custom variables
         id: customvars

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: "18"
 
       - name: Install dependencies
-        run: npm install --production=false && pip install --require-hashes -r requirements.txt
+        run: npm ci --production=false && pip install --require-hashes -r requirements.txt
 
       - name: Setup custom variables
         id: customvars

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: "18"
 
       - name: Install dependencies
-        run: npm install --production=false && pip install -r requirements.txt
+        run: npm install --require-hashes --production=false && pip install -r requirements.txt
 
       - name: Setup custom variables
         id: customvars

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
       - name: Install NPM dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build site
         run: npm run build


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

This PR replaces..

- `npm install` with `npm ci` which bypasses the `package.json` and goes directly to `package-lock.json` (where the hashes live)
- `pip install` with `pip install --require-hashes` which requires the hashes (which are now present in `requirements.txt`

The `requirements.txt` file was generated by using `pip-compile --generate-hashes -o requirements.txt requirements.in`

## security considerations

This helps us further lock down the exact packages that are installed and verify that they meet the expected hash values.
