### PR TITLE
Add a basic check to look for .env files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,20 @@ repos:
         description: Detect hardcoded secrets using Gitleaks
         language: docker_image
         entry: zricethezav/gitleaks:v8.15.0 protect --verbose --redact --staged
+
+  # fail if a commit includes a file named '.env'
+  # BAD:
+  #   .env
+  #   foo/.env
+  #
+  # Good:
+  # sample.env
+  # env.sample
+  # share/examples/sample.env
+  - repo: local
+    hooks:
+      - id: no-dotenv-files
+        name: "Files named .env are not allowed."
+        entry: "Files may not be named .env"
+        language: fail
+        files: '^(.*[/])?[.]env$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,4 +57,4 @@ repos:
         name: "Files named .env are not allowed."
         entry: "Files may not be named .env"
         language: fail
-        files: '^(.*[/])?[.]env$'
+        files: "^(.*[/])?[.]env$"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Changes proposed in this pull request

This is an extremely simple check that makes sure we don't accidentally commit a file named `.env` even if it doesn't have any secrets.  Literally all that it does is look for a file named `.env` and fails if it finds one.

## security considerations

This ought to help us keep a little safer, even if we don't actively use `.env` files.
